### PR TITLE
style: refine order review layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,10 @@
       background-size:400% 400%;animation:lightTheme 15s ease infinite;
     }
     @keyframes lightTheme{0%{background-position:0% 50%}50%{background-position:100% 50%}100%{background-position:0% 50%}}
-    *,*::before,*::after{transition:background-color .35s ease,color .35s ease,border-color .35s ease,box-shadow .35s ease}
+    *,*::before,*::after{
+      box-sizing:border-box;
+      transition:background-color .35s ease,color .35s ease,border-color .35s ease,box-shadow .35s ease
+    }
 
     .wrap{max-width:1100px;margin:0 auto;padding:16px}
 
@@ -128,7 +131,7 @@
     .fab a{background:#25D366;color:#fff;text-decoration:none}
 
     /* Modal + inputs */
-    dialog{border:none;padding:0;background:transparent;width:min(100%,480px)}
+    dialog{border:none;padding:0;background:transparent;width:min(96vw,600px)}
     dialog::backdrop{background:rgba(0,0,0,.6)}
     .modal{background:var(--card);border:1px solid var(--line);border-radius:16px;box-shadow:var(--shadow);display:flex;flex-direction:column;max-height:90vh;overflow:hidden;width:100%}
     html[data-theme="dark"] .modal{background:#0b0f16;border-color:rgba(255,255,255,.28);color:#ffffff}
@@ -136,6 +139,7 @@
     .modal header,.modal footer{padding:12px 14px}
     .modal header{display:flex;justify-content:space-between;align-items:center;border-bottom:1px solid var(--line)}
     .modal main{padding:14px;display:grid;gap:14px;overflow-y:auto;flex:1}
+    .modal footer{display:flex;justify-content:flex-end;gap:10px}
     #orderItems{max-height:200px;overflow-y:auto}
     @media(max-width:640px){dialog{width:100vw;height:100vh;border-radius:0}}
     .close{all:unset;cursor:pointer;font-weight:800}
@@ -328,7 +332,7 @@
           <div id="gpsNote" class="muted" style="font-size:.9rem"></div>
         </section>
       </main>
-      <footer class="right">
+      <footer>
         <button class="toggle" id="cancelBtn" data-en="Cancel" data-es="Cancelar">Cancel</button>
         <button class="btn alt" id="confirmBtn" data-en="Pay" data-es="Pagar">Pay</button>
       </footer>


### PR DESCRIPTION
## Summary
- add global box-sizing and flex footer for order dialog
- set responsive dialog width and align footer buttons

## Testing
- ⚠️ `npx --yes htmlhint index.html` (dependency install forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68c5037169c0832b81e76576b722d6a1